### PR TITLE
[ENGT-2178] Push on dev & prod ECRs

### DIFF
--- a/.github/workflows/push_to_ecr.yml
+++ b/.github/workflows/push_to_ecr.yml
@@ -1,4 +1,4 @@
-name: "Push Docker Image to Dev ECR"
+name: "Push Docker Image to ECR"
 on:
   workflow_dispatch:
   push:
@@ -7,10 +7,8 @@ on:
       - 'release-*'
 env:
   ROLE_ARN: arn:aws:iam::381491835868:role/grepr-flink-kubernetes-operator
-  ROLE_SESSION_NAME: GitHub_to_AWS_via_FederatedOIDC
-  AWS_REGION: us-east-1
-  IMAGE_NAME: flink-k8s-operator
-  ECR_URL: 381491835868.dkr.ecr.us-east-1.amazonaws.com
+  DEV_ECR: 381491835868.dkr.ecr.us-east-1.amazonaws.com/flink-k8s-operator
+  PRD_ECR: 992382778380.dkr.ecr.us-east-1.amazonaws.com/flink-k8s-operator
 jobs:
   build_image:
     runs-on: ubuntu-latest
@@ -21,8 +19,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: release-1.9
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -31,19 +27,21 @@ jobs:
           platforms: all
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1.7.0
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ env.ROLE_ARN }}
-          role-session-name: ${{ env.ROLE_SESSION_NAME }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: us-east-1
 
       - name: Login to Amazon ECR
-        id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registries: "381491835868,992382778380"
 
       - name: Publish Docker image to ECR
         run: |
-          docker buildx build --tag ${{ env.ECR_URL }}/${{ env.IMAGE_NAME }}:1.9.0-grepr --platform=linux/amd64,linux/arm64 --push --file Dockerfile . 
+          TAG="1.9.0-${GITHUB_SHA::7}"
+          docker buildx build --tag ${{ env.DEV_ECR }}:$TAG --tag ${{ env.PRD_ECR }}:$TAG \
+            --platform=linux/amd64,linux/arm64 --push --file Dockerfile .

--- a/.github/workflows/push_to_ecr.yml
+++ b/.github/workflows/push_to_ecr.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: release-1.9
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/push_to_ecr.yml
+++ b/.github/workflows/push_to_ecr.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Login to Amazon prod ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Publish Docker image to prod ECR
+      - name: Publish Docker image to dev & prod ECR
         run: |
           TAG="1.9.0-${GITHUB_SHA::7}"
           docker buildx build \

--- a/.github/workflows/push_to_ecr.yml
+++ b/.github/workflows/push_to_ecr.yml
@@ -1,6 +1,15 @@
 name: "Push Docker Image to ECR"
 on:
   workflow_dispatch:
+    inputs:
+      aws_account:
+        description: AWS Account ID
+        required: true
+        default: '381491835868'
+        type: choice
+        options:
+          - '381491835868' # dev
+          - '992382778380' # prod
   push:
     branches:
       - main
@@ -12,6 +21,8 @@ jobs:
       packages: write
       contents: read
       id-token: write
+    env:
+      AWS_ACCOUNT_ID: ${{ github.event.inputs.aws_account || '381491835868' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,28 +38,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Configure dev AWS credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::381491835868:role/GithubActionsRole
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/GithubActionsRole
           aws-region: us-east-1
 
-      - name: Login to Amazon dev ECR
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Configure prod AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::992382778380:role/GithubActionsRole
-          aws-region: us-east-1
-
-      - name: Login to Amazon prod ECR
+      - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Publish Docker image to dev & prod ECR
         run: |
           TAG="1.9.0-${GITHUB_SHA::7}"
           docker buildx build \
-            --tag 381491835868.dkr.ecr.us-east-1.amazonaws.com/flink-k8s-operator:$TAG \
-            --tag 992382778380.dkr.ecr.us-east-1.amazonaws.com/flink-k8s-operator:$TAG \
+            --tag ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/flink-k8s-operator:$TAG \
             --platform=linux/amd64,linux/arm64 --push --file Dockerfile .

--- a/.github/workflows/push_to_ecr.yml
+++ b/.github/workflows/push_to_ecr.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
       - 'release-*'
-env:
-  ROLE_ARN: arn:aws:iam::381491835868:role/grepr-flink-kubernetes-operator
-  DEV_ECR: 381491835868.dkr.ecr.us-east-1.amazonaws.com/flink-k8s-operator
-  PRD_ECR: 992382778380.dkr.ecr.us-east-1.amazonaws.com/flink-k8s-operator
 jobs:
   build_image:
     runs-on: ubuntu-latest
@@ -29,19 +25,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Configure AWS credentials
+      - name: Configure dev AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.ROLE_ARN }}
+          role-to-assume: arn:aws:iam::381491835868:role/GithubActionsRole
           aws-region: us-east-1
 
-      - name: Login to Amazon ECR
+      - name: Login to Amazon dev ECR
         uses: aws-actions/amazon-ecr-login@v2
-        with:
-          registries: "381491835868,992382778380"
 
-      - name: Publish Docker image to ECR
+      - name: Configure prod AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::992382778380:role/GithubActionsRole
+          aws-region: us-east-1
+
+      - name: Login to Amazon prod ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Publish Docker image to prod ECR
         run: |
           TAG="1.9.0-${GITHUB_SHA::7}"
-          docker buildx build --tag ${{ env.DEV_ECR }}:$TAG --tag ${{ env.PRD_ECR }}:$TAG \
+          docker buildx build \
+            --tag 381491835868.dkr.ecr.us-east-1.amazonaws.com/flink-k8s-operator:$TAG \
+            --tag 992382778380.dkr.ecr.us-east-1.amazonaws.com/flink-k8s-operator:$TAG \
             --platform=linux/amd64,linux/arm64 --push --file Dockerfile .


### PR DESCRIPTION
This enables https://github.com/grepr/grepr-server/blob/main/flink/kubernetes-operator/Dockerfile to pull it as base image both from dev and prod ECR repos.